### PR TITLE
「食べたい」「食べた」の機能追加

### DIFF
--- a/app/assets/stylesheets/have_eaten_statuses.scss
+++ b/app/assets/stylesheets/have_eaten_statuses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the have_eaten_statuses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/wanna_eat_statuses.scss
+++ b/app/assets/stylesheets/wanna_eat_statuses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the wanna_eat_statuses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/have_eaten_statuses_controller.rb
+++ b/app/controllers/have_eaten_statuses_controller.rb
@@ -3,20 +3,20 @@ class HaveEatenStatusesController < ApplicationController
   before_action :authenticate_jirolian!
 
   def create
-    wanna_eat_status = @jiro.have_eaten_statuses.new(jirolian_id: current_jirolian.id)
-    have_eaten_statuse.save
+    have_eaten_status = @jiro.have_eaten_statuses.new(jirolian_id: current_jirolian.id)
+    have_eaten_status.save
     redirect_to request.referer
   end
 
   def destroy
-    have_eaten_statuse = current_jirolian.have_eaten_statuses.find_by(jiro_id: @jiro.id)
-    have_eaten_statuse.destroy
+    have_eaten_status = current_jirolian.have_eaten_statuses.find_by(jiro_id: @jiro.id)
+    have_eaten_status.destroy
     redirect_to request.referer
   end
 
   private
 
-  def set_post
+  def set_jiro
     @jiro = Jiro.find(params[:jiro_id])
   end
 end

--- a/app/controllers/have_eaten_statuses_controller.rb
+++ b/app/controllers/have_eaten_statuses_controller.rb
@@ -1,2 +1,22 @@
 class HaveEatenStatusesController < ApplicationController
+  before_action :set_jiro
+  before_action :authenticate_jirolian!
+
+  def create
+    wanna_eat_status = @jiro.have_eaten_statuses.new(jirolian_id: current_jirolian.id)
+    have_eaten_statuse.save
+    redirect_to request.referer
+  end
+
+  def destroy
+    have_eaten_statuse = current_jirolian.have_eaten_statuses.find_by(jiro_id: @jiro.id)
+    have_eaten_statuse.destroy
+    redirect_to request.referer
+  end
+
+  private
+
+  def set_post
+    @jiro = Jiro.find(params[:jiro_id])
+  end
 end

--- a/app/controllers/have_eaten_statuses_controller.rb
+++ b/app/controllers/have_eaten_statuses_controller.rb
@@ -1,0 +1,2 @@
+class HaveEatenStatusesController < ApplicationController
+end

--- a/app/controllers/wanna_eat_statuses_controller.rb
+++ b/app/controllers/wanna_eat_statuses_controller.rb
@@ -1,0 +1,2 @@
+class WannaEatStatusesController < ApplicationController
+end

--- a/app/controllers/wanna_eat_statuses_controller.rb
+++ b/app/controllers/wanna_eat_statuses_controller.rb
@@ -4,19 +4,19 @@ class WannaEatStatusesController < ApplicationController
 
   def create
     wanna_eat_status = @jiro.wanna_eat_statuses.new(jirolian_id: current_jirolian.id)
-    wanna_eat_statuse.save
+    wanna_eat_status.save
     redirect_to request.referer
   end
 
   def destroy
-    wanna_eat_statuse = current_jirolian.wanna_eat_statuses.find_by(jiro_id: @jiro.id)
-    wanna_eat_statuse.destroy
+    wanna_eat_status = current_jirolian.wanna_eat_statuses.find_by(jiro_id: @jiro.id)
+    wanna_eat_status.destroy
     redirect_to request.referer
   end
 
   private
 
-  def set_post
+  def set_jiro
     @jiro = Jiro.find(params[:jiro_id])
   end
 end

--- a/app/controllers/wanna_eat_statuses_controller.rb
+++ b/app/controllers/wanna_eat_statuses_controller.rb
@@ -1,2 +1,22 @@
 class WannaEatStatusesController < ApplicationController
+  before_action :set_jiro
+  before_action :authenticate_jirolian!
+
+  def create
+    wanna_eat_status = @jiro.wanna_eat_statuses.new(jirolian_id: current_jirolian.id)
+    wanna_eat_statuse.save
+    redirect_to request.referer
+  end
+
+  def destroy
+    wanna_eat_statuse = current_jirolian.wanna_eat_statuses.find_by(jiro_id: @jiro.id)
+    wanna_eat_statuse.destroy
+    redirect_to request.referer
+  end
+
+  private
+
+  def set_post
+    @jiro = Jiro.find(params[:jiro_id])
+  end
 end

--- a/app/helpers/have_eaten_statuses_helper.rb
+++ b/app/helpers/have_eaten_statuses_helper.rb
@@ -1,0 +1,2 @@
+module HaveEatenStatusesHelper
+end

--- a/app/helpers/wanna_eat_statuses_helper.rb
+++ b/app/helpers/wanna_eat_statuses_helper.rb
@@ -1,0 +1,2 @@
+module WannaEatStatusesHelper
+end

--- a/app/models/have_eaten_status.rb
+++ b/app/models/have_eaten_status.rb
@@ -21,4 +21,6 @@
 class HaveEatenStatus < ApplicationRecord
   belongs_to :jiro
   belongs_to :jirolian
+
+  validates_uniqueness_of :jiro_id, scope: :jirolian_id
 end

--- a/app/models/have_eaten_status.rb
+++ b/app/models/have_eaten_status.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: have_eaten_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_have_eaten_statuses_on_jiro_id      (jiro_id)
+#  index_have_eaten_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+class HaveEatenStatus < ApplicationRecord
+  belongs_to :jiro
+  belongs_to :jirolian
+end

--- a/app/models/jiro.rb
+++ b/app/models/jiro.rb
@@ -23,7 +23,8 @@ class Jiro < ApplicationRecord
   has_one :facility
   has_many :menu_items
   has_many :business_hours
-  has_many :favorite_posts
+  has_many :wanna_eat_statuses, dependent: :destroy
+  has_many :have_eaten_statuses, dependent: :destroy
 
   enum payment_method: {default: 0, only_cash: 1, available_bisides_cash: 2}, _prefix: true
   enum how_to_order: {default: 0, meal_voucher_system: 1, order_system: 2}, _prefix: true

--- a/app/models/jiro.rb
+++ b/app/models/jiro.rb
@@ -33,4 +33,12 @@ class Jiro < ApplicationRecord
   validates :name, presence: true
   # VALID_PHONE_NUMBER_REGEX = /\A0(\d{1}[-(]?\d{4}|\d{2}[-(]?\d{3}|\d{3}[-(]?\d{2}|\d{4}[-(]?\d{1})[-)]?\d{4}\z|\A0[5789]0-?\d{4}-?\d{4}\z/.freeze
   # validates :phone_number, format: {with: VALID_PHONE_NUMBER_REGEX}
+
+  def checked_wanna_eat_by?(jirolian)
+    wanna_eat_statuses.where(jirolian_id: jirolian.id).exists?
+  end
+
+  def checked_have_eaten_by?(jirolian)
+    have_eaten_statuses.where(jirolian_id: jirolian.id).exists?
+  end
 end

--- a/app/models/jirolian.rb
+++ b/app/models/jirolian.rb
@@ -42,6 +42,8 @@
 class Jirolian < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :favorite_posts, dependent: :destroy
+  has_many :wanna_eat_statuses, dependent: :destroy
+  has_many :have_eaten_statuses, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/wanna_eat_status.rb
+++ b/app/models/wanna_eat_status.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: wanna_eat_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_wanna_eat_statuses_on_jiro_id      (jiro_id)
+#  index_wanna_eat_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+class WannaEatStatus < ApplicationRecord
+  belongs_to :jiro
+  belongs_to :jirolian
+end

--- a/app/models/wanna_eat_status.rb
+++ b/app/models/wanna_eat_status.rb
@@ -21,4 +21,6 @@
 class WannaEatStatus < ApplicationRecord
   belongs_to :jiro
   belongs_to :jirolian
+
+  validates_uniqueness_of :jiro_id, scope: :jirolian_id
 end

--- a/app/views/favorite_posts/_favorite_button.html.erb
+++ b/app/views/favorite_posts/_favorite_button.html.erb
@@ -1,0 +1,11 @@
+<% if post.favorited_by?(jirolian) %>
+  <%= link_to post_favorite_posts_path(post), method: :delete do %>
+    <span class="fa fa-heart like-btn-unlike"　aria-hidden="true" style="color: #ff2581;">
+    <%= post.favorite_posts.count %></span>
+  <% end %>
+<% else %>
+  <%= link_to post_favorite_posts_path(post), method: :post do %>
+    <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
+    <%= post.favorite_posts.count %></span>
+  <% end %>
+<% end %>

--- a/app/views/jirolians/show.html.erb
+++ b/app/views/jirolians/show.html.erb
@@ -31,15 +31,14 @@
     <a href="/jiros/<%= jiro.id %>"><%= jiro.name %></a><br>
     <p><%= post.content %></p>
     <p>トッピング：<%= post.called %></p>
-    <% if post.favorited_by?(current_jirolian) %>
-      <%= link_to post_favorite_posts_path(post), method: :delete do %>
-        <span class="fa fa-heart like-btn-unlike"　aria-hidden="true" style="color: #ff2581;"><%= post.favorite_posts.count %></span>
-      <% end %>
+    <% if jirolian_signed_in? %>
+      <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
     <% else %>
-      <%= link_to post_favorite_posts_path(post), method: :post do %>
-        <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;"><%= post.favorite_posts.count %></span>
+      <%= link_to new_jirolian_session_path do %>
+        <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
+        <%= post.favorite_posts.count %></span>
       <% end %>
-    <% end %>
+    <% end%>
   </div>
   <hr style="border-bottom: 3px double #8899a6;">
 <% end %>

--- a/app/views/jiros/_have_eaten_button.html.erb
+++ b/app/views/jiros/_have_eaten_button.html.erb
@@ -1,0 +1,11 @@
+<% if jiro.checked_have_eaten_by?(current_jirolian) %>
+  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :delete do %>
+    <span class="btn btn-success">
+    <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
+  <% end %>
+<% else %>
+  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :post do %>
+    <span class="btn btn-secondary">
+    <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
+  <% end %>
+<% end %>

--- a/app/views/jiros/_have_eaten_button.html.erb
+++ b/app/views/jiros/_have_eaten_button.html.erb
@@ -1,11 +1,18 @@
-<% if jiro.checked_have_eaten_by?(current_jirolian) %>
-  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :delete do %>
-    <span class="btn btn-success">
-    <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
+<% if jirolian_signed_in? %>
+  <% if jiro.checked_have_eaten_by?(current_jirolian) %>
+    <%= link_to jiro_have_eaten_statuses_path(jiro), method: :delete do %>
+      <span class="btn btn-success">
+      <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
+    <% end %>
+  <% else %>
+    <%= link_to jiro_have_eaten_statuses_path(jiro), method: :post do %>
+      <span class="btn btn-secondary">
+      <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
+    <% end %>
   <% end %>
 <% else %>
-  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :post do %>
-    <span class="btn btn-secondary">
+  <%= link_to new_jirolian_session_path do %>
+    <span class="btn btn-success">
     <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
   <% end %>
 <% end %>

--- a/app/views/jiros/_wanna_eat_button.html.erb
+++ b/app/views/jiros/_wanna_eat_button.html.erb
@@ -1,11 +1,18 @@
-<% if jiro.checked_wanna_eat_by?(current_jirolian) %>
-  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :delete do %>
-    <span class="btn btn-primary">
-    <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
+<% if jirolian_signed_in? %>
+  <% if jiro.checked_wanna_eat_by?(current_jirolian) %>
+    <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :delete do %>
+      <span class="btn btn-primary">
+      <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
+    <% end %>
+  <% else %>
+    <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :post do %>
+      <span class="btn btn-secondary">
+      <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
+    <% end %>
   <% end %>
 <% else %>
-  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :post do %>
-    <span class="btn btn-secondary">
+  <%= link_to new_jirolian_session_path do %>
+    <span class="btn btn-primary">
     <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
   <% end %>
 <% end %>

--- a/app/views/jiros/_wanna_eat_button.html.erb
+++ b/app/views/jiros/_wanna_eat_button.html.erb
@@ -1,0 +1,11 @@
+<% if jiro.checked_wanna_eat_by?(current_jirolian) %>
+  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :delete do %>
+    <span class="btn btn-primary">
+    <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
+  <% end %>
+<% else %>
+  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :post do %>
+    <span class="btn btn-secondary">
+    <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
+  <% end %>
+<% end %>

--- a/app/views/jiros/show.html.erb
+++ b/app/views/jiros/show.html.erb
@@ -1,4 +1,8 @@
 <%= button_to '食レポ', new_jiro_posts_path(@jiro), method: :get %>
+
+<%= render 'jiros/wanna_eat_button', jiro: @jiro %>
+<%= render 'jiros/have_eaten_button', jiro: @jiro %>
+
 <h1>店舗情報</h1>
   <h2>基本情報</h2>
     <table class="table">

--- a/app/views/jiros/show.html.erb
+++ b/app/views/jiros/show.html.erb
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css">
+
 <%= button_to '食レポ', new_jiro_posts_path(@jiro), method: :get %>
 
 <%= render 'jiros/wanna_eat_button', jiro: @jiro %>
@@ -112,8 +114,6 @@
         <% end %>
       </table>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css">
-
     <% if @posts.present? %>
       <% @posts.each do |post| %>
         <div>
@@ -122,15 +122,14 @@
           <a href="/jiros/<%= @jiro.id %>"><%= @jiro.name %></a><br>
           <p><%= post.content %></p>
           <p>トッピング：<%= post.called %></p>
-          <% if post.favorited_by?(current_jirolian) %>
-            <%= link_to post_favorite_posts_path(post), method: :delete do %>
-              <span class="fa fa-heart like-btn-unlike"　aria-hidden="true" style="color: #ff2581;"><%= post.favorite_posts.count %></span>
-            <% end %>
+          <% if jirolian_signed_in? %>
+            <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
           <% else %>
-            <%= link_to post_favorite_posts_path(post), method: :post do %>
-              <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;"><%= post.favorite_posts.count %></span>
+            <%= link_to new_jirolian_session_path do %>
+              <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
+              <%= post.favorite_posts.count %></span>
             <% end %>
-          <% end %>
+          <% end%>
         </div>
         <hr style="border-bottom: 3px double #8899a6;">
       <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,15 +8,14 @@
     <a href="/jiros/<%= jiro.id %>"><%= jiro.name %></a><br>
     <p><%= post.content %></p>
     <p>トッピング：<%= post.called %></p>
-    <% if post.favorited_by?(current_jirolian) %>
-      <%= link_to post_favorite_posts_path(post), method: :delete do %>
-        <span class="fa fa-heart like-btn-unlike"　aria-hidden="true" style="color: #ff2581;"><%= post.favorite_posts.count %></span>
-      <% end %>
+    <% if jirolian_signed_in? %>
+      <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
     <% else %>
-      <%= link_to post_favorite_posts_path(post), method: :post do %>
-        <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;"><%= post.favorite_posts.count %></span>
+      <%= link_to new_jirolian_session_path do %>
+        <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
+        <%= post.favorite_posts.count %></span>
       <% end %>
-    <% end %>
+    <% end%>
   </div>
   <hr style="border-bottom: 3px double #8899a6;">
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
       end
     end
     resource :posts, only: [:new, :create]
+    resource :wanna_eat_statuses, only: [:create, :destroy]
+    resource :have_eaten_statuses, only: [:create, :destroy]
   end
 
   # resources :jirolians, only: [:show] do

--- a/db/migrate/20210209163853_create_have_eaten_statuses.rb
+++ b/db/migrate/20210209163853_create_have_eaten_statuses.rb
@@ -1,0 +1,10 @@
+class CreateHaveEatenStatuses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :have_eaten_statuses do |t|
+      t.references :jiro, null: false, foreign_key: true
+      t.references :jirolian, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210209164748_create_wanna_eat_statuses.rb
+++ b/db/migrate/20210209164748_create_wanna_eat_statuses.rb
@@ -1,0 +1,10 @@
+class CreateWannaEatStatuses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :wanna_eat_statuses do |t|
+      t.references :jiro, null: false, foreign_key: true
+      t.references :jirolian, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_185625) do
+ActiveRecord::Schema.define(version: 2021_02_09_164748) do
 
   create_table "business_hours", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "jiro_id"
@@ -49,6 +49,15 @@ ActiveRecord::Schema.define(version: 2021_02_04_185625) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["jirolian_id"], name: "index_favorite_posts_on_jirolian_id"
     t.index ["post_id"], name: "index_favorite_posts_on_post_id"
+  end
+
+  create_table "have_eaten_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "jiro_id", null: false
+    t.bigint "jirolian_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["jiro_id"], name: "index_have_eaten_statuses_on_jiro_id"
+    t.index ["jirolian_id"], name: "index_have_eaten_statuses_on_jirolian_id"
   end
 
   create_table "jirolians", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -135,6 +144,19 @@ ActiveRecord::Schema.define(version: 2021_02_04_185625) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "wanna_eat_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "jiro_id", null: false
+    t.bigint "jirolian_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["jiro_id"], name: "index_wanna_eat_statuses_on_jiro_id"
+    t.index ["jirolian_id"], name: "index_wanna_eat_statuses_on_jirolian_id"
+  end
+
   add_foreign_key "favorite_posts", "jirolians"
   add_foreign_key "favorite_posts", "posts"
+  add_foreign_key "have_eaten_statuses", "jirolians"
+  add_foreign_key "have_eaten_statuses", "jiros"
+  add_foreign_key "wanna_eat_statuses", "jirolians"
+  add_foreign_key "wanna_eat_statuses", "jiros"
 end

--- a/spec/factories/have_eaten_statuses.rb
+++ b/spec/factories/have_eaten_statuses.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: have_eaten_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_have_eaten_statuses_on_jiro_id      (jiro_id)
+#  index_have_eaten_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+FactoryBot.define do
+  factory :have_eaten_status do
+    jiro { nil }
+    jirolian { nil }
+  end
+end

--- a/spec/factories/wanna_eat_statuses.rb
+++ b/spec/factories/wanna_eat_statuses.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: wanna_eat_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_wanna_eat_statuses_on_jiro_id      (jiro_id)
+#  index_wanna_eat_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+FactoryBot.define do
+  factory :wanna_eat_status do
+    jiro { nil }
+    jirolian { nil }
+  end
+end

--- a/spec/models/have_eaten_status_spec.rb
+++ b/spec/models/have_eaten_status_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: have_eaten_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_have_eaten_statuses_on_jiro_id      (jiro_id)
+#  index_have_eaten_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+require 'rails_helper'
+
+RSpec.describe HaveEatenStatus, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/wanna_eat_status_spec.rb
+++ b/spec/models/wanna_eat_status_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: wanna_eat_statuses
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  jiro_id     :bigint           not null
+#  jirolian_id :bigint           not null
+#
+# Indexes
+#
+#  index_wanna_eat_statuses_on_jiro_id      (jiro_id)
+#  index_wanna_eat_statuses_on_jirolian_id  (jirolian_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (jiro_id => jiros.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+require 'rails_helper'
+
+RSpec.describe WannaEatStatus, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- 店舗ページに店舗に対する「食べた」「食べたい」の投票ボタン追加
・ `WannaEatStatus` ：「食べたい」に関する中間テーブル
・ `HaveEatenStatus` ：「食べたい」に関する中間テーブル
基本的には `Post` に対するファボ機能と同様。
- 未ログインユーザーはボタン押すとログインページにリダイレクト

## その他
- 未ログインユーザーだとPost表示出来なかった部分を修正
- ファボ機能が `current_jirolian` に向けたものだっため。

## 画像キャプチャ
![image](https://user-images.githubusercontent.com/37606032/107412015-8d79eb80-6b52-11eb-9298-2f6dfdfb4337.png)
![image](https://user-images.githubusercontent.com/37606032/107412098-9ff42500-6b52-11eb-8d2c-fd73fc7f55ac.png)
![image](https://user-images.githubusercontent.com/37606032/107412128-aaaeba00-6b52-11eb-9c14-7a34a59f05e4.png)

## ERD
![image](https://user-images.githubusercontent.com/37606032/107412690-3d4f5900-6b53-11eb-903c-4b1a2968d0af.png)

