### PR TITLE
ユーザー同士のフォロー機能

### DIFF
--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/jirolians_controller.rb
+++ b/app/controllers/jirolians_controller.rb
@@ -14,6 +14,12 @@ class JiroliansController < ApplicationController
 
     have_eaten_jiro_ids = @jirolian.have_eaten_statuses.pluck(:jiro_id)
     @have_eaten_jiros = Jiro.where(id: have_eaten_jiro_ids)
+
+    followed_ids = Relationship.where(jirolian_id: @jirolian.id).pluck(:follow_id)
+    @followed_jirolians = Jirolian.where(id: followed_ids)
+
+    follower_ids = Relationship.where(follow_id: @jirolian.id).pluck(:jirolian_id)
+    @follower_jirolians = Jirolian.where(id: follower_ids)
   end
 
   def edit

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -5,10 +5,10 @@ class RelationshipsController < ApplicationController
     following = current_jirolian.follow(@jirolian)
     if following.save
       flash[:success] = 'ジロリアンをフォローしました'
-      redirect_to @jirolian
+      redirect_to "/jirolians/#{@jirolian.username}"
     else
       flash.now[:alert] = 'ジロリアンのフォローに失敗しました'
-      redirect_to @jirolian
+      redirect_to "/jirolians/#{@jirolian.username}"
     end
   end
 
@@ -16,16 +16,16 @@ class RelationshipsController < ApplicationController
     following = current_jirolian.unfollow(@jirolian)
     if following.destroy
       flash[:success] = 'ジロリアンのフォローを解除しました'
-      redirect_to @jirolian
+      redirect_to "/jirolians/#{@jirolian.username}"
     else
       flash.now[:alert] = 'ジロリアンのフォロー解除に失敗しました'
-      redirect_to @jirolian
+      redirect_to "/jirolians/#{@jirolian.username}"
     end
   end
 
   private
-  def
-    @jirolian = Jirolian.find(params[:relationship][:follow_id])
-  end
 
+  def set_jirolian
+    @jirolian = Jirolian.find(params[:follow_id])
+  end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,31 @@
+class RelationshipsController < ApplicationController
+  before_action :set_jirolian
+
+  def create
+    following = current_jirolian.follow(@jirolian)
+    if following.save
+      flash[:success] = 'ジロリアンをフォローしました'
+      redirect_to @jirolian
+    else
+      flash.now[:alert] = 'ジロリアンのフォローに失敗しました'
+      redirect_to @jirolian
+    end
+  end
+
+  def destroy
+    following = current_jirolian.unfollow(@jirolian)
+    if following.destroy
+      flash[:success] = 'ジロリアンのフォローを解除しました'
+      redirect_to @jirolian
+    else
+      flash.now[:alert] = 'ジロリアンのフォロー解除に失敗しました'
+      redirect_to @jirolian
+    end
+  end
+
+  private
+  def
+    @jirolian = Jirolian.find(params[:relationship][:follow_id])
+  end
+
+end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/jirolian.rb
+++ b/app/models/jirolian.rb
@@ -44,6 +44,10 @@ class Jirolian < ApplicationRecord
   has_many :favorite_posts, dependent: :destroy
   has_many :wanna_eat_statuses, dependent: :destroy
   has_many :have_eaten_statuses, dependent: :destroy
+  has_many :relationships
+  has_many :followings, through: :relationships, source: :follow
+  has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
+  has_many :followers, through: :reverse_of_relationships, source: :jirolian
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -53,4 +57,17 @@ class Jirolian < ApplicationRecord
   enum gender: {male: 0, female: 1, unanswered: 2}
 
   validates :username, presence: true
+
+  def follow(other_jirolian)
+    relationships.find_or_create_by(follow_id: other_jirolian.id) unless self == other_jirolian
+  end
+
+  def unfollow(other_jirolian)
+    relationship = relationships.find_by(follow_id: other_jirolian.id)
+    relationship.destroy if relationship
+  end
+
+  def following?(other_jirolian)
+    followings.include?(other_jirolian)
+  end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  follow_id   :bigint
+#  jirolian_id :bigint
+#
+# Indexes
+#
+#  index_relationships_on_follow_id                  (follow_id)
+#  index_relationships_on_jirolian_id                (jirolian_id)
+#  index_relationships_on_jirolian_id_and_follow_id  (jirolian_id,follow_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follow_id => jirolians.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+class Relationship < ApplicationRecord
+  belongs_to :jirolian
+  belongs_to :follow, class_name: 'Jirolian'
+
+  validates :jirolian_id, presence: true
+  validates :follow_id, presence: true
+end

--- a/app/views/jirolians/_follow_button.html.erb
+++ b/app/views/jirolians/_follow_button.html.erb
@@ -1,11 +1,11 @@
 <% unless current_jirolian == jirolian %>
   <% if current_jirolian.following?(jirolian) %>
-    <%= form_for(current_jirolian.relationships.find_by(follow_id: jirolian.id), html: { method: :delete }) do |f| %>
+    <%= form_with(model: current_jirolian.relationships.find_by(follow_id: jirolian.id), html: { method: :delete }) do |f| %>
       <%= hidden_field_tag :follow_id, jirolian.id %>
       <%= f.submit 'フォローを外す', class: 'btn btn-info' %>
     <% end %>
   <% else %>
-    <%= form_for(current_jirolian.relationships.build) do |f| %>
+    <%= form_with(model: current_jirolian.relationships.build) do |f| %>
       <%= hidden_field_tag :follow_id, jirolian.id %>
       <%= f.submit 'フォロー', class: 'btn btn-outline-info' %>
     <% end %>

--- a/app/views/jirolians/_follow_button.html.erb
+++ b/app/views/jirolians/_follow_button.html.erb
@@ -1,0 +1,13 @@
+<% unless current_jirolian == jirolian %>
+  <% if current_jirolian.following?(jirolian) %>
+    <%= form_for(current_jirolian.relationships.find_by(follow_id: jirolian.id), html: { method: :delete }) do |f| %>
+      <%= hidden_field_tag :follow_id, jirolian.id %>
+      <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+    <% end %>
+  <% else %>
+    <%= form_for(current_jirolian.relationships.build) do |f| %>
+      <%= hidden_field_tag :follow_id, jirolian.id %>
+      <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/jirolians/_follow_button.html.erb
+++ b/app/views/jirolians/_follow_button.html.erb
@@ -2,12 +2,12 @@
   <% if current_jirolian.following?(jirolian) %>
     <%= form_for(current_jirolian.relationships.find_by(follow_id: jirolian.id), html: { method: :delete }) do |f| %>
       <%= hidden_field_tag :follow_id, jirolian.id %>
-      <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+      <%= f.submit 'フォローを外す', class: 'btn btn-info' %>
     <% end %>
   <% else %>
     <%= form_for(current_jirolian.relationships.build) do |f| %>
       <%= hidden_field_tag :follow_id, jirolian.id %>
-      <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+      <%= f.submit 'フォロー', class: 'btn btn-outline-info' %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/jirolians/show.html.erb
+++ b/app/views/jirolians/show.html.erb
@@ -18,6 +18,8 @@
       <td><a href="<%=@jirolian.hp_url %>"><%= @jirolian.hp_url %></td></tr>
   </table>
 
+<%= render 'follow_button', jirolian: @jirolian, curretn_jirolian: current_jirolian %>
+
 <% if jirolian_signed_in? && @jirolian == current_jirolian %>
   <div><%= button_to "編集", "/jirolians/#{current_jirolian.username}/edit", method: :get %></div>
 <% end %>

--- a/app/views/jirolians/show.html.erb
+++ b/app/views/jirolians/show.html.erb
@@ -18,7 +18,9 @@
       <td><a href="<%=@jirolian.hp_url %>"><%= @jirolian.hp_url %></td></tr>
   </table>
 
-<%= render 'follow_button', jirolian: @jirolian, curretn_jirolian: current_jirolian %>
+<% if jirolian_signed_in? %>
+  <%= render 'follow_button', jirolian: @jirolian, current_jirolian: current_jirolian %>
+<% end %>
 
 <% if jirolian_signed_in? && @jirolian == current_jirolian %>
   <div><%= button_to "編集", "/jirolians/#{current_jirolian.username}/edit", method: :get %></div>
@@ -31,6 +33,8 @@
     <li class="tab tab-active">ジ活</li>
     <li class="tab">食べたい</li>
     <li class="tab">食べた</li>
+    <li class="tab">フォロー(<%= "#{@followed_jirolians.count}" %>)</li>
+    <li class="tab">フォロワー(<%= "#{@follower_jirolians.count}" %>)</li>
   </ul>
   <div class="tabbox-contents">
     <div class="tabbox box-show">
@@ -72,6 +76,22 @@
         <hr style="border-bottom: 3px double #8899a6;">
       <% end %>
     </div>
+    <div class="tabbox">
+      <% @followed_jirolians.each do |jirolian| %>
+        <table>
+          <tr><%= link_to jirolian.username, "/jirolians/#{jirolian.username}" %></tr>
+        </table>
+        <hr style="border-bottom: 3px double #8899a6;">
+      <% end %>
+    </div>
+    <div class="tabbox">
+      <% @follower_jirolians.each do |jirolian| %>
+        <table>
+          <tr><%= link_to jirolian.username, "/jirolians/#{jirolian.username}" %></tr>
+        </table>
+        <hr style="border-bottom: 3px double #8899a6;">
+      <% end %>      
+    </div>        
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,6 @@ Rails.application.routes.draw do
   get '/jirolians/:username' => 'jirolians#show'
   get '/jirolians/:username/edit' => 'jirolians#edit'
   patch '/jirolians/:username' => 'jirolians#update'
+
+  resources :relationships, only: [:create, :destroy]
 end

--- a/db/migrate/20210215122021_create_relationships.rb
+++ b/db/migrate/20210215122021_create_relationships.rb
@@ -1,0 +1,12 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.references :jirolian, foreign_key: true
+      t.references :follow, foreign_key: {to_table: :jirolians}
+
+      t.timestamps
+
+      t.index [:jirolian_id, :follow_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_164748) do
+ActiveRecord::Schema.define(version: 2021_02_15_122021) do
 
   create_table "business_hours", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "jiro_id"
@@ -144,6 +144,26 @@ ActiveRecord::Schema.define(version: 2021_02_09_164748) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "relation_ships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "jirolian_id", null: false
+    t.bigint "follow_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["follow_id"], name: "index_relation_ships_on_follow_id"
+    t.index ["jirolian_id", "follow_id"], name: "index_relation_ships_on_jirolian_id_and_follow_id", unique: true
+    t.index ["jirolian_id"], name: "index_relation_ships_on_jirolian_id"
+  end
+
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "jirolian_id"
+    t.bigint "follow_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["follow_id"], name: "index_relationships_on_follow_id"
+    t.index ["jirolian_id", "follow_id"], name: "index_relationships_on_jirolian_id_and_follow_id", unique: true
+    t.index ["jirolian_id"], name: "index_relationships_on_jirolian_id"
+  end
+
   create_table "wanna_eat_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "jiro_id", null: false
     t.bigint "jirolian_id", null: false
@@ -157,6 +177,10 @@ ActiveRecord::Schema.define(version: 2021_02_09_164748) do
   add_foreign_key "favorite_posts", "posts"
   add_foreign_key "have_eaten_statuses", "jirolians"
   add_foreign_key "have_eaten_statuses", "jiros"
+  add_foreign_key "relation_ships", "jirolians"
+  add_foreign_key "relation_ships", "jirolians", column: "follow_id"
+  add_foreign_key "relationships", "jirolians"
+  add_foreign_key "relationships", "jirolians", column: "follow_id"
   add_foreign_key "wanna_eat_statuses", "jirolians"
   add_foreign_key "wanna_eat_statuses", "jiros"
 end

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  follow_id   :bigint
+#  jirolian_id :bigint
+#
+# Indexes
+#
+#  index_relationships_on_follow_id                  (follow_id)
+#  index_relationships_on_jirolian_id                (jirolian_id)
+#  index_relationships_on_jirolian_id_and_follow_id  (jirolian_id,follow_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follow_id => jirolians.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+FactoryBot.define do
+  factory :relationship do
+    
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: relationships
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  follow_id   :bigint
+#  jirolian_id :bigint
+#
+# Indexes
+#
+#  index_relationships_on_follow_id                  (follow_id)
+#  index_relationships_on_jirolian_id                (jirolian_id)
+#  index_relationships_on_jirolian_id_and_follow_id  (jirolian_id,follow_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (follow_id => jirolians.id)
+#  fk_rails_...  (jirolian_id => jirolians.id)
+#
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- ユーザー( `Jirolian` )同士のフォロー機能を実装
- 機能実装にあたり `Relationship` モデルを作成。 `Jirolian` との多対多を実装。

<details>
  <summary>Relationship</summary>

```
 # == Schema Information
#
# Table name: relationships
#
#  id          :bigint           not null, primary key
#  created_at  :datetime         not null
#  updated_at  :datetime         not null
#  follow_id   :bigint
#  jirolian_id :bigint
#
# Indexes
#
#  index_relationships_on_follow_id                  (follow_id)
#  index_relationships_on_jirolian_id                (jirolian_id)
#  index_relationships_on_jirolian_id_and_follow_id  (jirolian_id,follow_id) UNIQUE
#
# Foreign Keys
#
#  fk_rails_...  (follow_id => jirolians.id)
#  fk_rails_...  (jirolian_id => jirolians.id)
#
class Relationship < ApplicationRecord
  belongs_to :jirolian
  belongs_to :follow, class_name: 'Jirolian'

  validates :jirolian_id, presence: true
  validates :follow_id, presence: true
end

```

</details>

### ログイン中の場合
- マイページ：フォローボタン非表示
- ユーザーページ：フォローボタン表示
　- 「フォロー」でcreate/「フォローを外す」でdestroy

### 未ログインの場合
フォローボタンを押すとログイン画面にリダイレクト

### 共通
- フォロー/フォロワーがユーザーページ/マイページで一覧として見れる。

![image](https://user-images.githubusercontent.com/37606032/107968034-344a0600-6ff1-11eb-89b5-dbf3cc554926.png)

![image](https://user-images.githubusercontent.com/37606032/107968064-3c09aa80-6ff1-11eb-9c31-b915d80f4029.png)

![image](https://user-images.githubusercontent.com/37606032/107968095-47f56c80-6ff1-11eb-8b3a-77de0646b9ff.png)

![image](https://user-images.githubusercontent.com/37606032/108262887-e0821d00-71a8-11eb-8782-c2c9e042a438.png)

![image](https://user-images.githubusercontent.com/37606032/108262927-eaa41b80-71a8-11eb-99ca-88b0c482a94e.png)

