### PR TITLE
店舗編集ボタンを追加及び新規作成の権限管理

### DIFF
--- a/app/controllers/jiros_controller.rb
+++ b/app/controllers/jiros_controller.rb
@@ -1,5 +1,6 @@
 class JirosController < ApplicationController
   before_action :set_jiro, expect: [:new, :create]
+  before_action :authenticate_jirolian!, except: [:show]
 
   def show
     @facility = @jiro.facility

--- a/app/models/jiro.rb
+++ b/app/models/jiro.rb
@@ -38,10 +38,10 @@ class Jiro < ApplicationRecord
   # validates :phone_number, format: {with: VALID_PHONE_NUMBER_REGEX}
 
   def checked_wanna_eat_by?(jirolian)
-    wanna_eat_statuses.where(jirolian_id: jirolian.id).exists?
+    wanna_eat_statuses.where(jirolian_id: jirolian.id).exists? if jirolian.present?
   end
 
   def checked_have_eaten_by?(jirolian)
-    have_eaten_statuses.where(jirolian_id: jirolian.id).exists?
+    have_eaten_statuses.where(jirolian_id: jirolian.id).exists? if jirolian.present?
   end
 end

--- a/app/views/jiros/_have_eaten_button.html.erb
+++ b/app/views/jiros/_have_eaten_button.html.erb
@@ -1,18 +1,11 @@
-<% if jirolian_signed_in? %>
-  <% if jiro.checked_have_eaten_by?(current_jirolian) %>
-    <%= link_to jiro_have_eaten_statuses_path(jiro), method: :delete do %>
-      <span class="btn btn-success">
-      <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
-    <% end %>
-  <% else %>
-    <%= link_to jiro_have_eaten_statuses_path(jiro), method: :post do %>
-      <span class="btn btn-secondary">
-      <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
-    <% end %>
+<% if jiro.checked_have_eaten_by?(current_jirolian) %>
+  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :delete do %>
+    <span class="btn btn-success">
+    <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
   <% end %>
 <% else %>
-  <%= link_to new_jirolian_session_path do %>
-    <span class="btn btn-success">
+  <%= link_to jiro_have_eaten_statuses_path(jiro), method: :post do %>
+    <span class="btn btn-secondary">
     <%= "食べた#{jiro.have_eaten_statuses.count}" %></span>
   <% end %>
 <% end %>

--- a/app/views/jiros/_wanna_eat_button.html.erb
+++ b/app/views/jiros/_wanna_eat_button.html.erb
@@ -1,18 +1,11 @@
-<% if jirolian_signed_in? %>
-  <% if jiro.checked_wanna_eat_by?(current_jirolian) %>
-    <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :delete do %>
-      <span class="btn btn-primary">
-      <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
-    <% end %>
-  <% else %>
-    <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :post do %>
-      <span class="btn btn-secondary">
-      <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
-    <% end %>
+<% if jiro.checked_wanna_eat_by?(current_jirolian) %>
+  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :delete do %>
+    <span class="btn btn-primary">
+    <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
   <% end %>
 <% else %>
-  <%= link_to new_jirolian_session_path do %>
-    <span class="btn btn-primary">
+  <%= link_to jiro_wanna_eat_statuses_path(jiro), method: :post do %>
+    <span class="btn btn-secondary">
     <%= "食べたい#{jiro.wanna_eat_statuses.count}" %></span>
   <% end %>
 <% end %>

--- a/app/views/jiros/show.html.erb
+++ b/app/views/jiros/show.html.erb
@@ -1,6 +1,7 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css">
 
 <%= button_to '食レポ', new_jiro_posts_path(@jiro), method: :get %>
+<%= button_to '情報修正', edit_jiro_path(@jiro), method: :get %>
 
 <%= render 'jiros/wanna_eat_button', jiro: @jiro %>
 <%= render 'jiros/have_eaten_button', jiro: @jiro %>


### PR DESCRIPTION
issue: https://github.com/zenichiro0419/Jiro-Tabetai/issues/38

## 概要
- 店舗ページの操作に該当する `jiros_controller` においてshowメソッド以外にログインを条件とした( `authnticate_jirolian!` )。未ログインの場合はログインページにリダレクト
- 店舗ページに店舗情報修正のボタンがなかったため設置(「情報修正」)
- 合わせて、店舗ページに存在する「食べた」「食べたい」のボタンの未ログイン時の操作をcontroller側に寄せてDRYにした。

