### PR TITLE
posts内のfavボタンのbug改修及びAjax対応

### DIFF
--- a/app/controllers/favorite_posts_controller.rb
+++ b/app/controllers/favorite_posts_controller.rb
@@ -5,14 +5,11 @@ class FavoritePostsController < ApplicationController
   def create
     favorite_post = @post.favorite_posts.new(jirolian_id: current_jirolian.id)
     favorite_post.save
-    flash[:success] = 'Liked post'
-    redirect_to request.referer
   end
 
   def destroy
     favorite_post = current_jirolian.favorite_posts.find_by(post_id: @post.id)
     favorite_post.destroy
-    redirect_to request.referer
   end
 
   private

--- a/app/views/favorite_posts/_favorite_button.html.erb
+++ b/app/views/favorite_posts/_favorite_button.html.erb
@@ -1,11 +1,11 @@
-<% if post.favorited_by?(jirolian) %>
-  <%= link_to post_favorite_posts_path(post), method: :delete do %>
-    <span class="fa fa-heart like-btn-unlike"　aria-hidden="true" style="color: #ff2581;">
-    <%= post.favorite_posts.count %></span>
+<% if post.favorited_by?(current_jirolian) %>
+  <%= link_to post_favorite_posts_path(post), method: :delete, remote: true do %>
+    <span class="fas fa-heart" style="color: #ff2581;"></span>
   <% end %>
+  <%= post.favorite_posts.count %>
 <% else %>
-  <%= link_to post_favorite_posts_path(post), method: :post do %>
-    <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
-    <%= post.favorite_posts.count %></span>
+  <%= link_to post_favorite_posts_path(post), method: :post, remote: true do %>
+    <span class="far fa-heart" style="color: #8899a6;"></span>
   <% end %>
+  <%= post.favorite_posts.count %>
 <% end %>

--- a/app/views/favorite_posts/create.js.erb
+++ b/app/views/favorite_posts/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('favorite_post_buttons_<%= @post.id %>').innerHTML = '<%= j(render @post) %>'

--- a/app/views/favorite_posts/destroy.js.erb
+++ b/app/views/favorite_posts/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('favorite_post_buttons_<%= @post.id %>').innerHTML = '<%= j(render @post) %>'

--- a/app/views/jirolians/show.html.erb
+++ b/app/views/jirolians/show.html.erb
@@ -50,12 +50,14 @@
           <p><%= "並び時間：#{post.wating_time}分" if post.wating_time.present? %></p>
           <p><%= "トッピング：#{post.called}" if post.called.present? %></p>
           <% if jirolian_signed_in? %>
-            <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
+            <div id="favorite_post_buttons_<%= post.id %>">
+              <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
+            </div>
           <% else %>
             <%= link_to new_jirolian_session_path do %>
-              <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
-              <%= post.favorite_posts.count %></span>
+              <span class="" style="color: #8899a6;"></span>
             <% end %>
+            <%= post.favorite_posts.count %><
           <% end%>
         </div>
         <hr style="border-bottom: 3px double #8899a6;">

--- a/app/views/jiros/show.html.erb
+++ b/app/views/jiros/show.html.erb
@@ -1,5 +1,3 @@
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css">
-
 <%= button_to '食レポ', new_jiro_posts_path(@jiro), method: :get %>
 <%= button_to '情報修正', edit_jiro_path(@jiro), method: :get %>
 
@@ -125,7 +123,7 @@
       </table>
 
     <% if @posts.present? %>
-      <%= render 'posts/display_posts', posts: @posts, current_jirolian: current_jirolian %>
+      <%= render 'posts/display_posts', posts: @posts %>
     <% else %>
       <div>この店舗に関する投稿は有りません。</div>  
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-
   </head>
 
   <body>

--- a/app/views/posts/_display_posts.html.erb
+++ b/app/views/posts/_display_posts.html.erb
@@ -8,12 +8,14 @@
     <p><%= "並び時間：#{post.wating_time}分" if post.wating_time.present? %></p>
     <p><%= "トッピング：#{post.called}" if post.called.present? %></p>
     <% if jirolian_signed_in? %>
-      <%= render 'favorite_posts/favorite_button', { jirolian: current_jirolian, post: post } %>
+      <div id="favorite_post_buttons_<%= post.id %>">
+        <%= render 'favorite_posts/favorite_button', { post: post } %>
+      </div>
     <% else %>
       <%= link_to new_jirolian_session_path do %>
-        <span class="fa fa-heart like-btn" aria-hidden="true" style="color: #8899a6;">
-        <%= post.favorite_posts.count %></span>
+        <span class="far fa-heart" aria-hidden="true" style="color: #8899a6;"></span>
       <% end %>
+      <%= post.favorite_posts.count %>
     <% end%>
   </div>
   <hr style="border-bottom: 3px double #8899a6;">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% if @posts.present? %>
   <%= render 'display_posts', posts: @posts, current_jirolian: current_jirolian %>
 <% else %>
-  <div>投稿は有りません。</div>  
-<% end %>  
+  <div>投稿は有りません。</div>
+<% end %>


### PR DESCRIPTION
issue: https://github.com/zenichiro0419/Jiro-Tabetai/issues/37

## 概要
- postsのfavボタンが「？」「！」の点滅になっていてfontawesomeが表示されていなかった。
- 原因を切り分けたところ、spanタグでfavカウントを挟んでいるのが原因だった（理由は不明）
- また、逐次favするたびにredirectしていたがAjaxで非同期にした。

![image](https://user-images.githubusercontent.com/37606032/109099070-c70f4100-7765-11eb-95c4-65335afff72c.png)
