### PR TITLE
店舗の「情報修正」にて各情報を編集できるようタブ設置

### DIFF
--- a/app/assets/stylesheets/jiro/edit_jiro_navi_bar.scss
+++ b/app/assets/stylesheets/jiro/edit_jiro_navi_bar.scss
@@ -1,0 +1,47 @@
+#nav {
+  list-style: none;
+  overflow: hidden;
+
+  li {
+    width: 300px;
+    text-align: center;
+    background-color: #fff;
+    float: left;
+
+    a {
+      position: relative;
+      display: inline-block;
+      font-weight: bold;
+      padding: 0.25em 0;
+      text-decoration: none;
+      color: #67c5ff;
+    }
+
+    a:before {
+      position: absolute;
+      content: "";
+      width: 100%;
+      height: 4px;
+      top: 100%;
+      left: 0;
+      border-radius: 3px;
+      background: #67c5ff;
+      transition: 0.2s;
+    }
+
+    a:hover:before {
+      top: -webkit-calc(100% - 3px);
+      top: calc(100% - 3px);
+    }
+  }
+}
+
+.edit_header {
+  display: flex;
+  .jiro_name {
+    font-size: 25px;
+    margin-right: 30px;
+  }
+  .jiro_btn {
+  }
+}

--- a/app/controllers/business_hours_controller.rb
+++ b/app/controllers/business_hours_controller.rb
@@ -1,10 +1,11 @@
 class BusinessHoursController < ApplicationController
+  before_action :set_jiro
+
   def edit
     @business_hours = BusinessHour.where(jiro_id: params[:jiro_id])
   end
 
   def update
-    @jiro = Jiro.find_by_id(params[:jiro_id])
     @business_hours = BusinessHour.where(jiro_id: params[:jiro_id])
 
     update_business_hours = push_update_business_hours(@business_hours)
@@ -18,6 +19,10 @@ class BusinessHoursController < ApplicationController
   end
 
   private
+
+  def set_jiro
+    @jiro = Jiro.find(params[:jiro_id])
+  end
 
   def push_update_business_hours(business_hours)
     update_business_hours = []

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -1,12 +1,12 @@
 class FacilitiesController < ApplicationController
+  before_action :set_jiro
+
   def edit
     @facility = Facility.find_by(jiro_id: params[:jiro_id])
   end
 
   def update
-    @jiro = Jiro.find_by_id(params[:jiro_id])
     @facility = @jiro.facility
-    # TODO: Header作成時にflashを埋め込む。
     if @facility.update(facility_params)
       flash.notice = '更新が完了しました。'
       redirect_to jiro_path(@jiro)
@@ -17,6 +17,10 @@ class FacilitiesController < ApplicationController
   end
 
   private
+
+  def set_jiro
+    @jiro = Jiro.find(params[:jiro_id])
+  end
 
   def facility_params
     params.permit(:jiro_id, :is_renge, :is_tissue, :is_apron, :is_water_server, :is_trash_box,

--- a/app/controllers/jiros_controller.rb
+++ b/app/controllers/jiros_controller.rb
@@ -60,7 +60,7 @@ class JirosController < ApplicationController
   private
 
   def set_jiro
-    @jiro = Jiro.find_by_id(params[:id])
+    @jiro = Jiro.find(params[:id])
   end
 
   # @pramas [Facility] facility

--- a/app/controllers/menu_items_controller.rb
+++ b/app/controllers/menu_items_controller.rb
@@ -1,4 +1,6 @@
 class MenuItemsController < ApplicationController
+  before_action :set_jiro
+
   def edit
     menu_items = MenuItem.where(jiro_id: params[:jiro_id])
     @main_menu_items = menu_items.main_menu
@@ -6,7 +8,6 @@ class MenuItemsController < ApplicationController
   end
 
   def update_main_menu
-    @jiro = Jiro.find_by_id(params[:jiro_id])
     menu_items = MenuItem.where(jiro_id: params[:jiro_id])
 
     @main_menu_items = menu_items.main_menu
@@ -38,6 +39,10 @@ class MenuItemsController < ApplicationController
   end
 
   private
+
+  def set_jiro
+    @jiro = Jiro.find(params[:jiro_id])
+  end
 
   def push_update_main_menu_items(main_menu_items)
     update_main_menu_items = []

--- a/app/views/business_hours/edit.html.erb
+++ b/app/views/business_hours/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'jiros/edit_jiro_navi_bar', jiro_id: @jiro.id %>
+
 <%= form_with(model: @business_hours, url: jiro_business_hours_path, method: :patch, local: true) do |form| %>
   <table>
   <% @business_hours.each_with_index do |business_hour, idx| %>

--- a/app/views/facilities/edit.html.erb
+++ b/app/views/facilities/edit.html.erb
@@ -1,102 +1,102 @@
-  <H3>基本設備</H3>
+  <%= render 'jiros/edit_jiro_navi_bar', jiro_id: @jiro.id %>
+
+  <%= form_with(model: @facility, url: jiro_facilities_path, method: :put, local: true) do |f| %>
   <table class="form-table">
-    <%= form_with(model: @facility, url: jiro_facilities_path, method: :put, local: true) do |f| %>
-      <tr>
-        <th><%= f.label :is_renge, "レンゲ" %></th>
-        <td>
-          <label><%= f.radio_button(:is_renge, true, class: "is_renge") %>あり</label>
-          <label><%= f.radio_button(:is_renge, false, class: "is_renge") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_tissue, "ティッシュ" %></th>
-        <td>
-          <label><%= f.radio_button(:is_tissue, true, class: "is_tissue") %>あり</label>
-          <label><%= f.radio_button(:is_tissue, false, class: "is_tissue") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_apron, "エプロン" %></th>
-        <td>
-          <label><%= f.radio_button(:is_apron, true, class: "is_apron") %>あり</label>
-          <label><%= f.radio_button(:is_apron, false, class: "is_apron") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_water_server, "ウォーターサーバー" %></th>
-        <td>
-          <label><%= f.radio_button(:is_water_server, true, class: "is_water_server") %>あり</label>
-          <label><%= f.radio_button(:is_water_server, false, class: "is_water_server") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_trash_box, "ゴミ箱" %></th>
-        <td>
-          <label><%= f.radio_button(:is_trash_box, true, class: "is_trash_box") %>あり</label>
-          <label><%= f.radio_button(:is_trash_box, false, class: "is_trash_box") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_vending_machine, "自動販売機" %></th>
-        <td>
-          <label><%= f.radio_button(:is_vending_machine, true, class: "is_vending_machine") %>あり</label>
-          <label><%= f.radio_button(:is_vending_machine, false, class: "is_vending_machine") %>なし</label>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :is_hair_tie, "ヘアゴム" %></th>
-        <td>
-          <label><%= f.radio_button(:is_hair_tie, true, class: "is_hair_tie") %>あり</label>
-          <label><%= f.radio_button(:is_hair_tie, false, class: "is_hair_tie") %>なし</label>
-        </td>
-      </tr>
-        <th><%= f.label :in_store_pending, "店内待ち数" %></th>
-        <td>
-          <%= f.number_field(:in_store_pending, class: "in_store_pending", size: 10, min: 0) %>人
-        </td>
-      </tr>
-      
-      <H3>卓上調味料</H3>
-      <tr>
-        <th><%= f.label :seasoning1, "調味料①" %></th>
-        <td>
-          <% Facility.seasoning1s.each_key do |seasoning| %>
-            <label><%= f.radio_button :seasoning1, seasoning %><%= seasoning %></label>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :seasoning2, "調味料②" %></th>
-        <td>
-          <% Facility.seasoning2s.each_key do |seasoning| %>
-            <label><%= f.radio_button :seasoning2, seasoning %><%= seasoning %></label>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :seasoning3, "調味料③" %></th>
-        <td>
-          <% Facility.seasoning3s.each_key do |seasoning| %>
-            <label><%= f.radio_button :seasoning3, seasoning %><%= seasoning %></label>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :seasoning4, "調味料④" %></th>
-        <td>
-          <% Facility.seasoning4s.each_key do |seasoning| %>
-            <label><%= f.radio_button :seasoning4, seasoning %><%= seasoning %></label>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :seasoning5, "調味料⑤" %></th>
-        <td>
-          <% Facility.seasoning5s.each_key do |seasoning| %>
-            <label><%= f.radio_button :seasoning5, seasoning %><%= seasoning %></label>
-          <% end %>
-        </td>
-      </tr>
-      <%= f.submit "更新" %>
-    <% end %>
-  </table>
+    <tr>
+      <th><%= f.label :is_renge, "レンゲ" %></th>
+      <td>
+        <label><%= f.radio_button(:is_renge, true, class: "is_renge") %>あり</label>
+        <label><%= f.radio_button(:is_renge, false, class: "is_renge") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_tissue, "ティッシュ" %></th>
+      <td>
+        <label><%= f.radio_button(:is_tissue, true, class: "is_tissue") %>あり</label>
+        <label><%= f.radio_button(:is_tissue, false, class: "is_tissue") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_apron, "エプロン" %></th>
+      <td>
+        <label><%= f.radio_button(:is_apron, true, class: "is_apron") %>あり</label>
+        <label><%= f.radio_button(:is_apron, false, class: "is_apron") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_water_server, "ウォーターサーバー" %></th>
+      <td>
+        <label><%= f.radio_button(:is_water_server, true, class: "is_water_server") %>あり</label>
+        <label><%= f.radio_button(:is_water_server, false, class: "is_water_server") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_trash_box, "ゴミ箱" %></th>
+      <td>
+        <label><%= f.radio_button(:is_trash_box, true, class: "is_trash_box") %>あり</label>
+        <label><%= f.radio_button(:is_trash_box, false, class: "is_trash_box") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_vending_machine, "自動販売機" %></th>
+      <td>
+        <label><%= f.radio_button(:is_vending_machine, true, class: "is_vending_machine") %>あり</label>
+        <label><%= f.radio_button(:is_vending_machine, false, class: "is_vending_machine") %>なし</label>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :is_hair_tie, "ヘアゴム" %></th>
+      <td>
+        <label><%= f.radio_button(:is_hair_tie, true, class: "is_hair_tie") %>あり</label>
+        <label><%= f.radio_button(:is_hair_tie, false, class: "is_hair_tie") %>なし</label>
+      </td>
+    </tr>
+      <th><%= f.label :in_store_pending, "店内待ち数" %></th>
+      <td>
+        <%= f.number_field(:in_store_pending, class: "in_store_pending", size: 10, min: 0) %>人
+      </td>
+    </tr>
+    
+    <tr>
+      <th><%= f.label :seasoning1, "調味料①" %></th>
+      <td>
+        <% Facility.seasoning1s.each_key do |seasoning| %>
+          <label><%= f.radio_button :seasoning1, seasoning %><%= seasoning %></label>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :seasoning2, "調味料②" %></th>
+      <td>
+        <% Facility.seasoning2s.each_key do |seasoning| %>
+          <label><%= f.radio_button :seasoning2, seasoning %><%= seasoning %></label>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :seasoning3, "調味料③" %></th>
+      <td>
+        <% Facility.seasoning3s.each_key do |seasoning| %>
+          <label><%= f.radio_button :seasoning3, seasoning %><%= seasoning %></label>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :seasoning4, "調味料④" %></th>
+      <td>
+        <% Facility.seasoning4s.each_key do |seasoning| %>
+          <label><%= f.radio_button :seasoning4, seasoning %><%= seasoning %></label>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <th><%= f.label :seasoning5, "調味料⑤" %></th>
+      <td>
+        <% Facility.seasoning5s.each_key do |seasoning| %>
+          <label><%= f.radio_button :seasoning5, seasoning %><%= seasoning %></label>
+        <% end %>
+      </td>
+    </tr>
+    </table>
+    <%= f.submit "更新" %>
+  <% end %>

--- a/app/views/jiros/_edit_jiro_navi_bar.html.erb
+++ b/app/views/jiros/_edit_jiro_navi_bar.html.erb
@@ -1,0 +1,16 @@
+<div class="edit_header">
+  <div class="jiro_name"><%= @jiro.name %></div>
+  <div class="jiro_btn">
+    <%= link_to jiro_path(@jiro) do %>
+      <span class="btn btn-primary">
+      <%= "店舗トップ" %></span>
+    <% end %>
+  <div>
+</div>
+<br>
+<ul id="nav">
+  <li><a href="/jiros/<%=jiro_id%>/edit">基礎情報</a></li>
+  <li><a href="/jiros/<%=jiro_id%>/business_hours/edit">営業時間</a></li>
+  <li><a href="/jiros/<%=jiro_id%>/facilities/edit">店内設備</a></li>
+  <li><a href="/jiros/<%=jiro_id%>/menu_items/edit">メニュー</a></li>
+</ul>

--- a/app/views/jiros/edit.html.erb
+++ b/app/views/jiros/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'edit_jiro_navi_bar', jiro_id: @jiro.id %>
+
 <H3>基本情報</H3>
     <%= form_with(model: @jiro, url: jiro_path, local: true) do |f| %>
       <table class="form-table">

--- a/app/views/menu_items/edit.html.erb
+++ b/app/views/menu_items/edit.html.erb
@@ -1,4 +1,4 @@
-<H3>メニュー</H3>
+<%= render 'jiros/edit_jiro_navi_bar', jiro_id: @jiro.id %>
 
 <H4>メインメニュー</H4>
 <%= form_with(model: @main_menu_items, url: update_main_menu_jiro_menu_items_path, method: :patch, local: true) do |form| %>


### PR DESCRIPTION
issue: https://github.com/zenichiro0419/Jiro-Tabetai/issues/47

## 概要
- 店舗情報編集ページは４つある（基本情報/メニュー/営業時間/店舗設備）
- それらの各編集ページにredirectするためのnavibarを設置

![image](https://user-images.githubusercontent.com/37606032/109187887-aaaaed00-77d5-11eb-9a54-bfb403651515.png)

![image](https://user-images.githubusercontent.com/37606032/109187925-b696af00-77d5-11eb-8b46-034746c66d19.png)
※レイアウトは後で修正